### PR TITLE
Fix error handling

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 ZERICO2005
+Copyright (c) 2024 - 2025 ZERICO2005
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+`quadmath_cpp` provides C++ overloads for `__float128` and `<quadmath.h>` functions. This allows you to use `<quadmath.h>` in templated functions. Instead of calling `sinq(x)` or `powq(x, y)`, you can now call `sin(x)` or `pow(x, y)` just like you would with `float` or `double`.
+
+`quadmath_cpp` also includes functions not present in `<quadmath.h>`, such as `islessgreater(x, y)` and `fpclassify(x)` from C++11, in addition to a few C23 functions like `iseqsig(x, y)`.
+
+Include the `quadmath_cpp.h` header in your code to use it. The header should compile fine on GCC from C++98 to C++23

--- a/README.txt
+++ b/README.txt
@@ -1,5 +1,0 @@
-quadmath_cpp provides C++ overloads for __float128 and quadmath.h. This allows you to use quadmath.h in templated functions. Instead of calling sinq(x) or powq(x, y), you can now call sin(x) or pow(x, y) just like you would with float or double.
-
-quadmath_cpp also includes C++11 <cmath> functions not present in quadmath.h, such as islessgreater(x, y) and fpclassify(x)
-
-Include the quadmath_cpp.h header in your code to use it. The header should compile fine on GCC from C++98 to C++23

--- a/quadmath_cpp.h
+++ b/quadmath_cpp.h
@@ -16,8 +16,8 @@
 #include <quadmath.h>
 
 #if __cplusplus >= 201103L
+	/* for fpclassify return values */
 	#include <cmath>
-	#include <cfenv>
 #endif
 
 /* Classification */
@@ -31,9 +31,11 @@ inline bool issignaling(__float128 x) { return (issignalingq(x) != 0); }
 inline bool isunordered(__float128 x, __float128 y) {
 	return ((isnanq(x) != 0) || (isnanq(y) != 0));
 }
+
 inline bool isnormal(__float128 x) {
 	return ((finiteq(x) != 0) && (fabsq(x) >= FLT128_MIN));
 }
+
 inline bool issubnormal(__float128 x) {
 	return ((finiteq(x) != 0) && (fabsq(x) < FLT128_MIN) && (x != static_cast<__float128>(0.0)));
 }
@@ -57,48 +59,39 @@ inline bool islessgreater(__float128 x, __float128 y) {
 	return ((x != y) && (isnanq(x) == 0) && (isnanq(y) == 0));
 }
 
-#if __cplusplus >= 201103L
-
 inline bool isless(__float128 x, __float128 y) {
-	bool ignore_fe_expection = !std::fetestexcept(FE_INVALID);
-	bool result = (x < y);
-	if (ignore_fe_expection) { std::feclearexcept(FE_INVALID); }
-	return result;
+	if ((isnanq(x) != 0) || (isnanq(y) != 0)) {
+		return false;
+	}
+	return (x < y);
 }
+
 inline bool islessequal(__float128 x, __float128 y) {
-	bool ignore_fe_expection = !std::fetestexcept(FE_INVALID);
-	bool result = (x <= y);
-	if (ignore_fe_expection) { std::feclearexcept(FE_INVALID); }
-	return result;
+	if ((isnanq(x) != 0) || (isnanq(y) != 0)) {
+		return false;
+	}
+	return (x <= y);
 }
+
 inline bool isgreater(__float128 x, __float128 y) {
-	bool ignore_fe_expection = !std::fetestexcept(FE_INVALID);
-	bool result = (x > y);
-	if (ignore_fe_expection) { std::feclearexcept(FE_INVALID); }
-	return result;
+	if ((isnanq(x) != 0) || (isnanq(y) != 0)) {
+		return false;
+	}
+	return (x > y);
 }
+
 inline bool isgreaterequal(__float128 x, __float128 y) {
-	bool ignore_fe_expection = !std::fetestexcept(FE_INVALID);
-	bool result = (x >= y);
-	if (ignore_fe_expection) { std::feclearexcept(FE_INVALID); }
-	return result;
+	if ((isnanq(x) != 0) || (isnanq(y) != 0)) {
+		return false;
+	}
+	return (x >= y);
 }
-
-#endif /* __cplusplus >= 201103L */
-
 
 /* signaling comparison */
 
-#if __cplusplus >= 201103L
-
 inline bool iseqsig(__float128 x, __float128 y) {
-	if ((isnanq(x) != 0) || (isnanq(y) != 0)) {
-		std::feraiseexcept(FE_INVALID);
-	}
-	return (x == y);
+	return ((x >= y) && (x <= y));
 }
-
-#endif /* __cplusplus >= 201103L */
 
 /* Manipulation */
 
@@ -110,10 +103,10 @@ inline __float128 nexttoward(__float128 x, long double y) { return nextafterq(x,
 /* Float Exponents */
 
 inline int ilogb(__float128 x) { return ilogbq(x); }
-inline __float128 frexp  (__float128 x, int* exp) { return frexpq  (x, exp); }
-inline __float128 ldexp  (__float128 x, int  exp) { return ldexpq  (x, exp); }
-inline __float128 scalbn (__float128 x, int  exp) { return scalbnq (x, exp); }
-inline __float128 scalbln(__float128 x, long exp) { return scalblnq(x, exp); }
+inline __float128 frexp  (__float128 x, int* expon) { return frexpq  (x, expon); }
+inline __float128 ldexp  (__float128 x, int  expon) { return ldexpq  (x, expon); }
+inline __float128 scalbn (__float128 x, int  expon) { return scalbnq (x, expon); }
+inline __float128 scalbln(__float128 x, long expon) { return scalblnq(x, expon); }
 
 /* Arithmetic */
 

--- a/quadmath_cpp.h
+++ b/quadmath_cpp.h
@@ -1,5 +1,5 @@
 /*
-**	Author: zerico2005 (2024)
+**	Author: zerico2005 (2024 - 2025)
 **	Project: quadmath_cpp
 **	License: MIT License
 **	A copy of the MIT License should be included with
@@ -13,8 +13,12 @@
 // <quadmath.h> overloads
 //------------------------------------------------------------------------------
 
-#include <cmath>
 #include <quadmath.h>
+
+#if __cplusplus >= 201103L
+	#include <cmath>
+	#include <cfenv>
+#endif
 
 /* Classification */
 
@@ -24,11 +28,84 @@ inline bool isinf(__float128 x) { return (isinfq(x) != 0); }
 inline bool isnan(__float128 x) { return (isnanq(x) != 0); }
 inline bool issignaling(__float128 x) { return (issignalingq(x) != 0); }
 
+inline bool isunordered(__float128 x, __float128 y) {
+	return ((isnanq(x) != 0) || (isnanq(y) != 0));
+}
+inline bool isnormal(__float128 x) {
+	return ((finiteq(x) != 0) && (fabsq(x) >= FLT128_MIN));
+}
+inline bool issubnormal(__float128 x) {
+	return ((finiteq(x) != 0) && (fabsq(x) < FLT128_MIN) && (x != static_cast<__float128>(0.0)));
+}
+
+#if __cplusplus >= 201103L
+
+inline int fpclassify(__float128 x) {
+	return
+		isinfq(x)                          ? FP_INFINITE :
+		isnanq(x)                          ? FP_NAN      :
+		x == static_cast<__float128>(0.0)  ? FP_ZERO     :
+		isnormal(x)                        ? FP_NORMAL   :
+		FP_SUBNORMAL;
+}
+
+#endif /* __cplusplus >= 201103L */
+
+/* Quiet Compairison */
+
+inline bool islessgreater(__float128 x, __float128 y) {
+	return ((x != y) && (isnanq(x) == 0) && (isnanq(y) == 0));
+}
+
+#if __cplusplus >= 201103L
+
+inline bool isless(__float128 x, __float128 y) {
+	bool ignore_fe_expection = !std::fetestexcept(FE_INVALID);
+	bool result = (x < y);
+	if (ignore_fe_expection) { std::feclearexcept(FE_INVALID); }
+	return result;
+}
+inline bool islessequal(__float128 x, __float128 y) {
+	bool ignore_fe_expection = !std::fetestexcept(FE_INVALID);
+	bool result = (x <= y);
+	if (ignore_fe_expection) { std::feclearexcept(FE_INVALID); }
+	return result;
+}
+inline bool isgreater(__float128 x, __float128 y) {
+	bool ignore_fe_expection = !std::fetestexcept(FE_INVALID);
+	bool result = (x > y);
+	if (ignore_fe_expection) { std::feclearexcept(FE_INVALID); }
+	return result;
+}
+inline bool isgreaterequal(__float128 x, __float128 y) {
+	bool ignore_fe_expection = !std::fetestexcept(FE_INVALID);
+	bool result = (x >= y);
+	if (ignore_fe_expection) { std::feclearexcept(FE_INVALID); }
+	return result;
+}
+
+#endif /* __cplusplus >= 201103L */
+
+
+/* signaling comparison */
+
+#if __cplusplus >= 201103L
+
+inline bool iseqsig(__float128 x, __float128 y) {
+	if ((isnanq(x) != 0) || (isnanq(y) != 0)) {
+		std::feraiseexcept(FE_INVALID);
+	}
+	return (x == y);
+}
+
+#endif /* __cplusplus >= 201103L */
+
 /* Manipulation */
 
 inline __float128 fabs(__float128 x) { return fabsq(x); }
 inline __float128 copysign(__float128 x, __float128 y) { return copysignq(x, y); }
 inline __float128 nextafter(__float128 x, __float128 y) { return nextafterq(x, y); }
+inline __float128 nexttoward(__float128 x, long double y) { return nextafterq(x, static_cast<__float128>(y)); }
 
 /* Float Exponents */
 
@@ -51,12 +128,12 @@ inline __float128 hypot(__float128 x, __float128 y) { return hypotq(x, y); }
 /* Remainder and Modulus */
 
 inline __float128 fmod(__float128 x, __float128  y) { return fmodq(x, y); }
-inline __float128 modf(__float128 x, __float128* int_part) { return modfq(x, int_part); }
 inline __float128 remainder(__float128 x, __float128 y) { return remainderq(x, y); }
 inline __float128 remquo(__float128 x, __float128 y, int* quo) { return remquoq(x, y, quo); }
 
 /* Rounding */
 
+inline __float128 modf(__float128 x, __float128* integral_part) { return modfq(x, integral_part); }
 inline __float128 trunc(__float128 x) { return truncq(x); }
 inline __float128 floor(__float128 x) { return floorq(x); }
 inline __float128 ceil (__float128 x) { return ceilq (x); }
@@ -103,67 +180,5 @@ inline __float128 erf (__float128 x) { return erfq (x); }
 inline __float128 erfc(__float128 x) { return erfcq(x); }
 inline __float128 lgamma(__float128 x) { return lgammaq(x); }
 inline __float128 tgamma(__float128 x) { return tgammaq(x); }
-
-//------------------------------------------------------------------------------
-// C++11 <cmath> overloads
-//------------------------------------------------------------------------------
-
-/* Manipulation */
-
-inline __float128 nexttoward(__float128 x, long double y) {
-	return nextafterq(x, static_cast<__float128>(y));
-}
-
-/* Compairison */
-
-inline bool isgreater(__float128 x, __float128 y) {
-	return (x > y);
-}
-inline bool isgreaterequal(__float128 x, __float128 y) {
-	return (x >= y);
-}
-inline bool isless(__float128 x, __float128 y) {
-	return (x < y);
-}
-inline bool islessequal(__float128 x, __float128 y) {
-	return (x <= y);
-}
-inline bool islessgreater(__float128 x, __float128 y) {
-	return (x < y) || (x > y);
-}
-
-/* Classification */
-
-inline bool isunordered(__float128 x, __float128 y) {
-	return (isnanq(x) != 0) || (isnanq(y) != 0);
-}
-
-inline bool isnormal(__float128 x) {
-	return (finiteq(x) != 0 && fabsq(x) >= FLT128_MIN);
-}
-
-inline int fpclassify(__float128 x) {
-	return
-		isinfq(x)                          ? FP_INFINITE :
-		isnanq(x)                          ? FP_NAN      :
-		x == static_cast<__float128>(0.0)  ? FP_ZERO     :
-		isnormal(x)                        ? FP_NORMAL   :
-		FP_SUBNORMAL;
-}
-
-//------------------------------------------------------------------------------
-// Additional overloads
-//------------------------------------------------------------------------------
-
-/** @brief calls `exp(x * M_LN10q)`  */
-inline __float128 exp10(__float128 x) {
-	return expq(x * M_LN10q);
-}
-
-/** @brief calls `*p_sinh = sinhq(x); *p_cosh = coshq(x);`  */
-inline void sinhcosh(__float128 x, __float128* p_sinh, __float128* p_cosh) {
-	*p_sinh = sinhq(x);
-	*p_cosh = coshq(x);
-}
 
 #endif /* QUADMATH_CPP_H */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,7 +16,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "./bin")
 	set(CMAKE_CXX_STANDARD 11)
 
 # Compiler Flags
-	set(OPT_FLAG -O2 -g)
+	set(OPT_FLAG -O0 -g)
 
 # Source Files
 	file(GLOB_RECURSE SRC_FILES "${SRC_DIR}/*.c" "${SRC_DIR}/*.cpp")
@@ -26,8 +26,8 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "./bin")
 # Compile Options
 
 	target_compile_options(${PROJECT_NAME} PRIVATE
-		${OPT_FLAG}
-		-Wall -Wextra -Wpedantic -Wshadow -Wfloat-conversion -Wconversion -Wformat=2
+		${OPT_FLAG} -fsignaling-nans
+		-Wall -Wextra -Wshadow -Wfloat-conversion -Wconversion -Wformat=2
 	)
 
 	target_link_libraries(${PROJECT_NAME} PRIVATE "quadmath")

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -1,16 +1,25 @@
 /*
-**	Author: zerico2005 (2024)
+**	Author: zerico2005 (2024 - 2025)
 **	Project: quadmath_cpp
 **	License: MIT License
 **	A copy of the MIT License should be included with
 **	this project. If not, see https://opensource.org/license/MIT
 */
 
+#include <cassert>
+#include <cstdio>
+#include <limits>
+
+#if __cplusplus >= 201103L
+	#include <cfenv>
+	#include <cmath>
+#endif
+
+#include <quadmath.h>
+
 #include "../../quadmath_cpp.h"
 
-#include <cstdio>
-
-int main(void) {
+void basic_test() {
 	__float128 val_0 = 1.234q;
 	__float128 val_1 = 5.678q;
 	__float128 result = pow(val_0, val_1);
@@ -24,6 +33,42 @@ int main(void) {
 	quadmath_snprintf(buf_result, sizeof(buf_result), "%.*Qf", FLT128_DIG, result);
 
 	printf("pow(%s, %s) = %s\n", buf_0, buf_1, buf_result);
+}
 
+#if __cplusplus >= 201103L
+void quiet_comparison_test() {
+	__float128 x = std::numeric_limits<__float128>::signaling_NaN();
+	__float128 y = 100.0q;
+	
+	assert(isnan(x));
+	assert(issignaling(x));
+	
+	std::feclearexcept(FE_ALL_EXCEPT);
+	
+	bool signaling_less_than = (x < y);
+	assert(signaling_less_than == false);
+	assert(std::fetestexcept(FE_INVALID) == true);
+	
+	std::feclearexcept(FE_ALL_EXCEPT);
+	
+	bool quiet_less_than = isless(x, y);
+	assert(quiet_less_than == false);
+	assert(std::fetestexcept(FE_INVALID) == false);
+	
+	std::feclearexcept(FE_ALL_EXCEPT);
+	
+	bool subnormal_test = issubnormal(x);
+	assert(subnormal_test == false);
+	assert(std::fetestexcept(FE_INVALID) == false);
+	
+	printf("Passed the quiet comparison test\n");
+}
+#else
+void quiet_comparison_test() { return; }
+#endif
+
+int main(void) {
+	basic_test();
+	quiet_comparison_test();
 	return 0;
 }


### PR DESCRIPTION
Fixed the behavior of quiet comparisons `isless islessequal isgreater isgreaterequal` along with `iseqsig`. Additionally, `exp10` was removed since its naive implementation is likely not useful. `sinhcosh` was removed since it is non-standard.